### PR TITLE
one more use-case for native build

### DIFF
--- a/.github/workflows/native-image-on-demand.yml
+++ b/.github/workflows/native-image-on-demand.yml
@@ -106,6 +106,7 @@ jobs:
         run: |
           mkdir -p native-image-config-dir
           echo 'Bob->Alice: Hello' | java -Djava.awt.headless=true -agentlib:native-image-agent=config-output-dir=native-image-config-dir -jar "./build/libs/plantuml-pdf-$RELEASE_VERSION.jar" -tpng -pipe
+          printf 'Bob->Alice: Hello\nBob<--Alice\n...\nBob->Alice: Hello again\nBob<--Alice' | java -Djava.awt.headless=true -agentlib:native-image-agent=config-merge-dir=native-image-config-dir -jar "./build/libs/plantuml-pdf-$RELEASE_VERSION.jar" -tpng -pipe
           echo 'Bob->Alice: Hello' | java -Djava.awt.headless=true -agentlib:native-image-agent=config-merge-dir=native-image-config-dir -jar "./build/libs/plantuml-pdf-$RELEASE_VERSION.jar" -tpdf -pipe
           echo 'Bob->Alice: Hello' | java -Djava.awt.headless=true -agentlib:native-image-agent=config-merge-dir=native-image-config-dir -jar "./build/libs/plantuml-pdf-$RELEASE_VERSION.jar" -ttxt -pipe
           echo 'Bob->Alice: Hello' | java -Djava.awt.headless=true -agentlib:native-image-agent=config-merge-dir=native-image-config-dir -jar "./build/libs/plantuml-pdf-$RELEASE_VERSION.jar" -tuxt -pipe

--- a/.github/workflows/native-image.yml
+++ b/.github/workflows/native-image.yml
@@ -60,6 +60,7 @@ jobs:
         run: |
           mkdir native-image-config-dir
           echo 'Bob->Alice: Hello' | java -Djava.awt.headless=true -agentlib:native-image-agent=config-output-dir=native-image-config-dir -jar "./build/libs/plantuml-pdf-${{ inputs.release-version }}.jar" -tpng -pipe
+          printf 'Bob->Alice: Hello\nBob<--Alice\n...\nBob->Alice: Hello again\nBob<--Alice' | java -Djava.awt.headless=true -agentlib:native-image-agent=config-merge-dir=native-image-config-dir -jar "./build/libs/plantuml-pdf-${{ inputs.release-version }}.jar" -tpng -pipe
           echo 'Bob->Alice: Hello' | java -Djava.awt.headless=true -agentlib:native-image-agent=config-merge-dir=native-image-config-dir -jar "./build/libs/plantuml-pdf-${{ inputs.release-version }}.jar" -tpdf -pipe
           echo 'Bob->Alice: Hello' | java -Djava.awt.headless=true -agentlib:native-image-agent=config-merge-dir=native-image-config-dir -jar "./build/libs/plantuml-pdf-${{ inputs.release-version }}.jar" -ttxt -pipe
           echo 'Bob->Alice: Hello' | java -Djava.awt.headless=true -agentlib:native-image-agent=config-merge-dir=native-image-config-dir -jar "./build/libs/plantuml-pdf-${{ inputs.release-version }}.jar" -tuxt -pipe


### PR DESCRIPTION
The following simple sequence diagrams produces an error when rendering a `png` with your native build `plantuml-linux-amd64-1.2023.10`:

```
Bob->Alice: Hello
Bob<--Alice
...
Bob->Alice: Hello again
Bob<--Alice
```

See resulting image: 
![KO.png](https://github.com/yuzutech/plantuml/assets/6212720/946ab2cc-6c11-4883-adc8-1074d2cef1ee)

We've detected this issue initially on our internal Kroki server, but it can also be reproduced on `kroki.io`:
https://kroki.io/plantuml/png/eNpzyk_StXPMyUxOtVLwSM3Jyedyyk-y0dUFC3Hp6emB-KgqFBLTEzPzkNUBAN4_FTU=

It seems that the `...` syntax is the trigger here, although it's not obvious in the stacktrace.

Anyway, adding this use-case to the GraalVM configuration training seems to be enough to get the missing bits in the native image, and render the expected result:
![OK.png](https://github.com/yuzutech/plantuml/assets/6212720/e46da310-7065-4768-9fc0-a8c43e725d0a)

A test binary (linux-amd64 only) is available here: https://github.com/thomasgl-orange/plantuml/releases/tag/v1.2023.10-tgl2
